### PR TITLE
Fix cluster seralization

### DIFF
--- a/src/MeanShiftClusteringPlugin.cpp
+++ b/src/MeanShiftClusteringPlugin.cpp
@@ -249,8 +249,6 @@ void MeanShiftClusteringPlugin::init()
     _meanShift.init();
     _offscreenBuffer.releaseContext();
 
-    // Do an initial computation
-    _settingsAction.getComputeAction().trigger();
 }
 
 bool MeanShiftClusteringPlugin::canCompute() const

--- a/src/SettingsAction.cpp
+++ b/src/SettingsAction.cpp
@@ -16,8 +16,8 @@ SettingsAction::SettingsAction(MeanShiftClusteringPlugin* meanShiftClusteringPlu
     _colorByAction(this, "Color by", QStringList({"Pseudo-random colors", "Color map"}), "Color map"),
     _colorMapAction(this, "Color map"),
     _randomSeedAction(this, "Random seed"),
-    _updateColorsManuallyAction(this, "Update colors manually", false),
-    _applyColorsAction(this, "Apply colors"),
+    _updateColorsManuallyAction(this, "Update clustering manually", false),
+    _applyColorsAction(this, "Update clustering"),
     _computeAction(this, "Compute")
 {
     setText("Settings");
@@ -25,6 +25,8 @@ SettingsAction::SettingsAction(MeanShiftClusteringPlugin* meanShiftClusteringPlu
     _sigmaAction.setUpdateDuringDrag(false);
     _randomSeedAction.setUpdateDuringDrag(false);
     _computeAction.setVisible(false);
+
+    _applyColorsAction.setToolTip("Clusters are updated automatically when settings are changed\n(Unless manual updates are toggled on.)");
 
     addAction(&_dimensionOneAction);
     addAction(&_dimensionTwoAction);


### PR DESCRIPTION
Currently, the MeanShift plugin starts computing when it's created.
But this results in overwriting any existing clustering, e.g. when loading a project.

Steps to reproduce the issue:
1. Load some data and apply mean-shift clustering
2. Merge any clusters you like
3. Save as a project
4. Load the project: The clusters are not merged anymore since the mean-shift clustering computed new clusters. 

This PR removes the automatic compute trigger. The user will now need to manually click compute the first time (as in any other analysis plugin).

